### PR TITLE
Need to account for null-terminating character of strings

### DIFF
--- a/src_op/euler3d_cpu_double_op.cpp
+++ b/src_op/euler3d_cpu_double_op.cpp
@@ -265,10 +265,10 @@ int main(int argc, char** argv)
 
       char** new_argv = (char**)malloc((argc+1)*sizeof(char*));
       for (int i=0; i<argc; i++) {
-        new_argv[i] = (char*)malloc(strlen(argv[i])*sizeof(char));
+        new_argv[i] = (char*)malloc((strlen(argv[i]+1))*sizeof(char));
         strcpy(new_argv[i], argv[i]);
       }
-      new_argv[argc] = (char*)malloc(strlen("OP_MAPS_BASE_INDEX=0")*sizeof(char));
+      new_argv[argc] = (char*)malloc((strlen("OP_MAPS_BASE_INDEX=0")+1)*sizeof(char));
       sprintf(new_argv[argc], "OP_MAPS_BASE_INDEX=%d", base_array_index);
       argc++;
 


### PR DESCRIPTION
This caused a buffer overflow on gcc-8.3.0 for optimisation
settings -O1 and higher (including -Og)