### PR TITLE
Fix/sycl type casting

### DIFF
--- a/sycl/calc_rms_kernel_kernel.cpp
+++ b/sycl/calc_rms_kernel_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_calc_rms_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  calc_rms_kernel");
+    printf(" kernel routine w/o indirection:  calc_rms_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/calc_rms_kernel_kernel.cpp
+++ b/sycl/calc_rms_kernel_kernel.cpp
@@ -49,7 +49,7 @@ void op_par_loop_calc_rms_kernel(char const *name, op_set set,
     int reduct_size  = 0;
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(double));
     reduct_size   = MAX(reduct_size,sizeof(double));
-    reallocReductArrays(reduct_bytes);
+    allocReductArrays(reduct_bytes, "double");
     reduct_bytes = 0;
     arg1.data   = OP_reduct_h + reduct_bytes;
     int arg1_offset = reduct_bytes/sizeof(double);
@@ -59,7 +59,7 @@ void op_par_loop_calc_rms_kernel(char const *name, op_set set,
       }
     }
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(double));
-    mvReductArraysToDevice(reduct_bytes);
+    mvReductArraysToDevice(reduct_bytes, "double");
     cl::sycl::buffer<double,1> *reduct = static_cast<cl::sycl::buffer<double,1> *>((void*)OP_reduct_d);
 
     cl::sycl::buffer<double,1> *arg0_buffer = static_cast<cl::sycl::buffer<double,1>*>((void*)arg0.data_d);
@@ -108,7 +108,7 @@ void op_par_loop_calc_rms_kernel(char const *name, op_set set,
     std::cout << e.what() << std::endl;exit(-1);
     }
     //transfer global reduction data back to CPU
-    mvReductArraysToHost(reduct_bytes);
+    mvReductArraysToHost(reduct_bytes, "double");
     for ( int b=0; b<maxblocks; b++ ){
       for ( int d=0; d<1; d++ ){
         arg1h[d] = arg1h[d] + ((double *)arg1.data)[d+b*1];
@@ -116,6 +116,7 @@ void op_par_loop_calc_rms_kernel(char const *name, op_set set,
     }
     arg1.data = (char *)arg1h;
     op_mpi_reduce(&arg1,arg1h);
+    freeReductArrays("double");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/calculate_dt_kernel_kernel.cpp
+++ b/sycl/calculate_dt_kernel_kernel.cpp
@@ -32,7 +32,7 @@ void op_par_loop_calculate_dt_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  calculate_dt_kernel");
+    printf(" kernel routine w/o indirection:  calculate_dt_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/compute_step_factor_kernel_kernel.cpp
+++ b/sycl/compute_step_factor_kernel_kernel.cpp
@@ -35,7 +35,7 @@ void op_par_loop_compute_step_factor_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  compute_step_factor_kernel");
+    printf(" kernel routine w/o indirection:  compute_step_factor_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/compute_step_factor_kernel_kernel.cpp
+++ b/sycl/compute_step_factor_kernel_kernel.cpp
@@ -44,7 +44,7 @@ void op_par_loop_compute_step_factor_kernel(char const *name, op_set set,
     //transfer constants to GPU
     int consts_bytes = 0;
     consts_bytes += ROUND_UP(1*sizeof(double));
-    reallocConstArrays(consts_bytes);
+    allocConstArrays(consts_bytes, "double");
     consts_bytes = 0;
     arg2.data   = OP_consts_h + consts_bytes;
     int arg2_offset = consts_bytes/sizeof(double);
@@ -52,7 +52,7 @@ void op_par_loop_compute_step_factor_kernel(char const *name, op_set set,
       ((double *)arg2.data)[d] = arg2h[d];
     }
     consts_bytes += ROUND_UP(1*sizeof(double));
-    mvConstArraysToDevice(consts_bytes);
+    mvConstArraysToDevice(consts_bytes, "double");
     cl::sycl::buffer<double,1> *consts = static_cast<cl::sycl::buffer<double,1> *>((void*)OP_consts_d);
 
     //set SYCL execution parameters
@@ -116,6 +116,7 @@ void op_par_loop_compute_step_factor_kernel(char const *name, op_set set,
     }catch(cl::sycl::exception const &e) {
     std::cout << e.what() << std::endl;exit(-1);
     }
+    freeConstArrays("double");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/copy_double_kernel_kernel.cpp
+++ b/sycl/copy_double_kernel_kernel.cpp
@@ -27,7 +27,7 @@ void op_par_loop_copy_double_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  copy_double_kernel");
+    printf(" kernel routine w/o indirection:  copy_double_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/count_bad_vals_kernel.cpp
+++ b/sycl/count_bad_vals_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_count_bad_vals(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  count_bad_vals");
+    printf(" kernel routine w/o indirection:  count_bad_vals\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/count_bad_vals_kernel.cpp
+++ b/sycl/count_bad_vals_kernel.cpp
@@ -49,7 +49,7 @@ void op_par_loop_count_bad_vals(char const *name, op_set set,
     int reduct_size  = 0;
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(int));
     reduct_size   = MAX(reduct_size,sizeof(int));
-    reallocReductArrays(reduct_bytes);
+    allocReductArrays(reduct_bytes, "int");
     reduct_bytes = 0;
     arg1.data   = OP_reduct_h + reduct_bytes;
     int arg1_offset = reduct_bytes/sizeof(int);
@@ -59,7 +59,7 @@ void op_par_loop_count_bad_vals(char const *name, op_set set,
       }
     }
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(int));
-    mvReductArraysToDevice(reduct_bytes);
+    mvReductArraysToDevice(reduct_bytes, "int");
     cl::sycl::buffer<int,1> *reduct = static_cast<cl::sycl::buffer<int,1> *>((void*)OP_reduct_d);
 
     cl::sycl::buffer<double,1> *arg0_buffer = static_cast<cl::sycl::buffer<double,1>*>((void*)arg0.data_d);
@@ -117,7 +117,7 @@ void op_par_loop_count_bad_vals(char const *name, op_set set,
     std::cout << e.what() << std::endl;exit(-1);
     }
     //transfer global reduction data back to CPU
-    mvReductArraysToHost(reduct_bytes);
+    mvReductArraysToHost(reduct_bytes, "int");
     for ( int b=0; b<maxblocks; b++ ){
       for ( int d=0; d<1; d++ ){
         arg1h[d] = arg1h[d] + ((int *)arg1.data)[d+b*1];
@@ -125,6 +125,7 @@ void op_par_loop_count_bad_vals(char const *name, op_set set,
     }
     arg1.data = (char *)arg1h;
     op_mpi_reduce(&arg1,arg1h);
+    freeReductArrays("int");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/count_non_zeros_kernel.cpp
+++ b/sycl/count_non_zeros_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_count_non_zeros(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  count_non_zeros");
+    printf(" kernel routine w/o indirection:  count_non_zeros\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/count_non_zeros_kernel.cpp
+++ b/sycl/count_non_zeros_kernel.cpp
@@ -49,7 +49,7 @@ void op_par_loop_count_non_zeros(char const *name, op_set set,
     int reduct_size  = 0;
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(int));
     reduct_size   = MAX(reduct_size,sizeof(int));
-    reallocReductArrays(reduct_bytes);
+    allocReductArrays(reduct_bytes, "int");
     reduct_bytes = 0;
     arg1.data   = OP_reduct_h + reduct_bytes;
     int arg1_offset = reduct_bytes/sizeof(int);
@@ -59,7 +59,7 @@ void op_par_loop_count_non_zeros(char const *name, op_set set,
       }
     }
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(int));
-    mvReductArraysToDevice(reduct_bytes);
+    mvReductArraysToDevice(reduct_bytes, "int");
     cl::sycl::buffer<int,1> *reduct = static_cast<cl::sycl::buffer<int,1> *>((void*)OP_reduct_d);
 
     cl::sycl::buffer<double,1> *arg0_buffer = static_cast<cl::sycl::buffer<double,1>*>((void*)arg0.data_d);
@@ -110,7 +110,7 @@ void op_par_loop_count_non_zeros(char const *name, op_set set,
     std::cout << e.what() << std::endl;exit(-1);
     }
     //transfer global reduction data back to CPU
-    mvReductArraysToHost(reduct_bytes);
+    mvReductArraysToHost(reduct_bytes, "int");
     for ( int b=0; b<maxblocks; b++ ){
       for ( int d=0; d<1; d++ ){
         arg1h[d] = arg1h[d] + ((int *)arg1.data)[d+b*1];
@@ -118,6 +118,7 @@ void op_par_loop_count_non_zeros(char const *name, op_set set,
     }
     arg1.data = (char *)arg1h;
     op_mpi_reduce(&arg1,arg1h);
+    freeReductArrays("int");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/dampen_ewt_kernel.cpp
+++ b/sycl/dampen_ewt_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_dampen_ewt(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  dampen_ewt");
+    printf(" kernel routine w/o indirection:  dampen_ewt\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/down_v2_kernel_post_kernel.cpp
+++ b/sycl/down_v2_kernel_post_kernel.cpp
@@ -32,7 +32,7 @@ void op_par_loop_down_v2_kernel_post(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  down_v2_kernel_post");
+    printf(" kernel routine w/o indirection:  down_v2_kernel_post\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/down_v2_kernel_pre_kernel.cpp
+++ b/sycl/down_v2_kernel_pre_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_down_v2_kernel_pre(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  down_v2_kernel_pre");
+    printf(" kernel routine w/o indirection:  down_v2_kernel_pre\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/get_min_dt_kernel_kernel.cpp
+++ b/sycl/get_min_dt_kernel_kernel.cpp
@@ -31,7 +31,7 @@ void op_par_loop_get_min_dt_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  get_min_dt_kernel");
+    printf(" kernel routine w/o indirection:  get_min_dt_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/get_min_dt_kernel_kernel.cpp
+++ b/sycl/get_min_dt_kernel_kernel.cpp
@@ -52,7 +52,7 @@ void op_par_loop_get_min_dt_kernel(char const *name, op_set set,
     int reduct_size  = 0;
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(double));
     reduct_size   = MAX(reduct_size,sizeof(double));
-    reallocReductArrays(reduct_bytes);
+    allocReductArrays(reduct_bytes, "double");
     reduct_bytes = 0;
     arg1.data   = OP_reduct_h + reduct_bytes;
     int arg1_offset = reduct_bytes/sizeof(double);
@@ -62,7 +62,7 @@ void op_par_loop_get_min_dt_kernel(char const *name, op_set set,
       }
     }
     reduct_bytes += ROUND_UP(maxblocks*1*sizeof(double));
-    mvReductArraysToDevice(reduct_bytes);
+    mvReductArraysToDevice(reduct_bytes, "double");
     cl::sycl::buffer<double,1> *reduct = static_cast<cl::sycl::buffer<double,1> *>((void*)OP_reduct_d);
 
     cl::sycl::buffer<double,1> *arg0_buffer = static_cast<cl::sycl::buffer<double,1>*>((void*)arg0.data_d);
@@ -111,7 +111,7 @@ void op_par_loop_get_min_dt_kernel(char const *name, op_set set,
     std::cout << e.what() << std::endl;exit(-1);
     }
     //transfer global reduction data back to CPU
-    mvReductArraysToHost(reduct_bytes);
+    mvReductArraysToHost(reduct_bytes, "double");
     for ( int b=0; b<maxblocks; b++ ){
       for ( int d=0; d<1; d++ ){
         arg1h[d] = MIN(arg1h[d],((double *)arg1.data)[d+b*1]);
@@ -119,6 +119,7 @@ void op_par_loop_get_min_dt_kernel(char const *name, op_set set,
     }
     arg1.data = (char *)arg1h;
     op_mpi_reduce(&arg1,arg1h);
+    freeReductArrays("double");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/identify_differences_kernel.cpp
+++ b/sycl/identify_differences_kernel.cpp
@@ -29,7 +29,7 @@ void op_par_loop_identify_differences(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  identify_differences");
+    printf(" kernel routine w/o indirection:  identify_differences\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/initialize_variables_kernel_kernel.cpp
+++ b/sycl/initialize_variables_kernel_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_initialize_variables_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  initialize_variables_kernel");
+    printf(" kernel routine w/o indirection:  initialize_variables_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/residual_kernel_kernel.cpp
+++ b/sycl/residual_kernel_kernel.cpp
@@ -29,7 +29,7 @@ void op_par_loop_residual_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  residual_kernel");
+    printf(" kernel routine w/o indirection:  residual_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/time_step_kernel_kernel.cpp
+++ b/sycl/time_step_kernel_kernel.cpp
@@ -37,7 +37,7 @@ void op_par_loop_time_step_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  time_step_kernel");
+    printf(" kernel routine w/o indirection:  time_step_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/time_step_kernel_kernel.cpp
+++ b/sycl/time_step_kernel_kernel.cpp
@@ -46,7 +46,7 @@ void op_par_loop_time_step_kernel(char const *name, op_set set,
     //transfer constants to GPU
     int consts_bytes = 0;
     consts_bytes += ROUND_UP(1*sizeof(int));
-    reallocConstArrays(consts_bytes);
+    allocConstArrays(consts_bytes, "int");
     consts_bytes = 0;
     arg0.data   = OP_consts_h + consts_bytes;
     int arg0_offset = consts_bytes/sizeof(int);
@@ -54,7 +54,7 @@ void op_par_loop_time_step_kernel(char const *name, op_set set,
       ((int *)arg0.data)[d] = arg0h[d];
     }
     consts_bytes += ROUND_UP(1*sizeof(int));
-    mvConstArraysToDevice(consts_bytes);
+    mvConstArraysToDevice(consts_bytes, "int");
     cl::sycl::buffer<int,1> *consts = static_cast<cl::sycl::buffer<int,1> *>((void*)OP_consts_d);
 
     //set SYCL execution parameters
@@ -121,6 +121,7 @@ void op_par_loop_time_step_kernel(char const *name, op_set set,
     }catch(cl::sycl::exception const &e) {
     std::cout << e.what() << std::endl;exit(-1);
     }
+    freeConstArrays("int");
   }
   op_mpi_set_dirtybit_cuda(nargs, args);
   op2_queue->wait();

--- a/sycl/up_post_kernel_kernel.cpp
+++ b/sycl/up_post_kernel_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_up_post_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  up_post_kernel");
+    printf(" kernel routine w/o indirection:  up_post_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/zero_1d_array_kernel_kernel.cpp
+++ b/sycl/zero_1d_array_kernel_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_zero_1d_array_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  zero_1d_array_kernel");
+    printf(" kernel routine w/o indirection:  zero_1d_array_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);

--- a/sycl/zero_5d_array_kernel_kernel.cpp
+++ b/sycl/zero_5d_array_kernel_kernel.cpp
@@ -28,7 +28,7 @@ void op_par_loop_zero_5d_array_kernel(char const *name, op_set set,
 
 
   if (OP_diags>2) {
-    printf(" kernel routine w/o indirection:  zero_5d_array_kernel");
+    printf(" kernel routine w/o indirection:  zero_5d_array_kernel\n");
   }
 
   op_mpi_halo_exchanges_cuda(set, nargs, args);


### PR DESCRIPTION
When creating sycl::buffer objects, TYPE must be specific, no more generic char objects.

Means a change to OP2 API as type must be specified when allocating buffers, and the reallocate method has to go unless a record of the old buffer type is kept (which would need new globals in OP2).

PENDING PARALLEL PULL REQUEST IN OP2 REPO